### PR TITLE
Add test metadata to the context

### DIFF
--- a/nose2_html_report/html_report.py
+++ b/nose2_html_report/html_report.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import copy
 import os
 import traceback
 import unittest
@@ -88,7 +89,8 @@ class HTMLReporter(Plugin):
             'name': test_case_import_path,
             'description': test_case_doc,
             'result': event.outcome,
-            'traceback': formatted_traceback
+            'traceback': formatted_traceback,
+            'metadata': copy.copy(event.metadata)
         })
 
     def afterSummaryReport(self, event):

--- a/nose2_html_report/html_report.py
+++ b/nose2_html_report/html_report.py
@@ -20,10 +20,11 @@ class HTMLReporter(Plugin):
         super(HTMLReporter, self).__init__(*args, **kwargs)
         self.summary_stats = {'total': 0}
         self.test_results = []
+        default_template_path = os.path.join(os.path.dirname(__file__), 'templates', 'report.html') 
 
         self._config = {
             'report_path': os.path.realpath(self.config.as_str('path', default='report.html')),
-            'template': os.path.join(os.path.dirname(__file__), 'templates', 'report.html')
+            'template':  os.path.realpath(self.config.as_str('template', default=default_template_path))
         }
 
     def _sort_test_results(self):


### PR DESCRIPTION
This allows to display data from other plugins when we use customed templates.