### PR TITLE
Fetch fonts over HTTPS to avoid mixed content

### DIFF
--- a/nose2_html_report/templates/report.html
+++ b/nose2_html_report/templates/report.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <title>Report</title>
-        <link href="http://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.8/css/materialize.min.css">
         <style>
             code > pre {


### PR DESCRIPTION
From Chrome:
Mixed Content: The page at 'https://xxxx' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/icon?family=Material+Icons'. This request has been blocked; the content must be served over HTTPS.