### PR TITLE
fix autocomplete terms unicode decode utf-8 error

### DIFF
--- a/nose2_html_report/html_report.py
+++ b/nose2_html_report/html_report.py
@@ -106,7 +106,7 @@ class HTMLReporter(Plugin):
             'test_report_title': 'Test Report',
             'test_summary': self.summary_stats,
             'test_results': sorted_test_results,
-            'autocomplete_terms': json.dumps(self._generate_search_terms()),
+            'autocomplete_terms': json.dumps(self._generate_search_terms(), ensure_ascii=False),
             'timestamp': datetime.utcnow().strftime('%Y/%m/%d %H:%M:%S UTC')
         }
         template = load_template(self._config['template'])


### PR DESCRIPTION
Using : Python 2.7 and Windows OS
error:
File "U:\wd\dar-dev\ant-ws\build\opt\nose2_html_report-0.6.0\Lib\site-packages\nose2_html_report\html_report.py", line 109, in afterSummaryReport
       'autocomplete_terms': json.dumps(self._generate_search_terms()),
        File "D:\Program Files (x86)\Python27\lib\json\__init__.py", line 244, in dumps
         return _default_encoder.encode(obj)
      File "D:\Program Files (x86)\Python27\lib\json\encoder.py", line 207, in encode
        chunks = self.iterencode(o, _one_Generating HTML reportshot=True)
        File "D:\Program Files (x86)\Python27\lib\json\encoder.py", line 270, in iterencode
         return _iterencode(o, 0)
      UnicodeDecodeError: 'utf8' codec can't decode byte 0xea in position 1: invalid continuation byte